### PR TITLE
Added BinanceFutures, csv merge, 1970 removal

### DIFF
--- a/candles_sync/candles_sync.py
+++ b/candles_sync/candles_sync.py
@@ -2,6 +2,9 @@
 """
 candles_sync.py
 
+Multi-exchange candle synchronization with Exchange Adapter pattern.
+Supports Bitfinex and Binance Futures with identical internal processing pipeline.
+
 This script synchronizes historical candle data for a given exchange/ticker
 for a single timeframe (1m, 1h, 1D). You can run it repeatedly to keep your
 local partitions up to date.
@@ -11,26 +14,9 @@ Partitions:
     - 1h -> stored monthly (YYYY-MM.csv)
     - 1D -> stored yearly (YYYY.csv)
 
-Features:
-- First‐time sync (no ".gotstart" file): queries from the epoch (0) to build full history.
-- Incremental sync (".gotstart" exists):
-    1) Finds missing partitions grouped by consecutive runs (e.g., daily runs).
-    2) For each run, performs a chunked fetch from:
-         (last-known-candle **inclusive**) or earliest partition of that run,
-       **whichever is earlier**, up to that run's last partition (end of that day/month/year).
-    3) Writes data or creates empty CSV files for each missing partition in the run.
-    4) Jumps to the next missing run without re-fetching unneeded ranges.
-    5) After all runs, re-checks the last partition and **always re-polls the last saved candle**
-       to refresh its values (e.g., volume corrections).
-    6) **Chunk audit (no re-query):** every API response chunk (if it has at least 2 candles) is
-       audited for internal gaps between its **first** and **last** returned candles. Any missing
-       intervals inside that window are **synthesized locally** with `volume=0` and
-       `O=H=L=C=previous_close` (no extra API calls).
-
 Usage:
-    python candles_sync.py --exchange BITFINEX --ticker tBTCUSD [--end YYYY-MM-DD]
-    or
-    python candles_sync.py --exchange BITFINEX --ticker tBTCUSD --timeframe 1m
+    python candles_sync.py --exchange BINANCE_FUTURES --ticker BTCUSDT --timeframe 1m
+    python candles_sync.py --exchange BITFINEX --ticker tBTCUSD --timeframe 1h
 """
 
 from __future__ import annotations
@@ -43,18 +29,14 @@ import requests
 import pandas as pd
 import decimal
 import json
-from typing import List, Optional, Tuple
+from typing import List, Optional, Tuple, Dict, Any
 from datetime import datetime, timezone, timedelta
 from urllib.parse import urlencode
+from abc import ABC, abstractmethod
 
 # ------------------------------ Constants --------------------------------- #
 
-BITFINEX_API_URL = "https://api-pub.bitfinex.com/v2/candles/trade:{}:{}/hist"
 ROOT_PATH = os.path.expanduser("~/.corky")
-
-API_LIMIT = 10000
-BACKOFF_INITIAL_SECONDS = 30
-BACKOFF_MAX_SECONDS = 300
 HTTP_TIMEOUT_SECONDS = 30
 
 VALID_TIMEFRAMES = {"1m", "1h", "1D"}
@@ -110,11 +92,260 @@ COLOR_TIMESTAMPS = Fore.MAGENTA
 COLOR_ROWS       = Fore.RED
 COLOR_NEW        = Fore.WHITE
 COLOR_VAR        = Fore.CYAN
-COLOR_TYPE       = Fore.YELLOW
-COLOR_DESC       = Fore.MAGENTA
-COLOR_REQ        = Fore.RED + "[REQUIRED]" + Style.RESET_ALL
 
-HEADERS = {"User-Agent": USER_AGENT}
+# ========================== EXCHANGE ADAPTERS ========================== #
+
+class ExchangeAdapter(ABC):
+    """Abstract base class for exchange-specific implementations."""
+    
+    @abstractmethod
+    def get_exchange_name(self) -> str:
+        """Return normalized exchange name for directory structure."""
+        pass
+    
+    @abstractmethod
+    def normalize_symbol(self, symbol: str) -> str:
+        """Normalize symbol format for this exchange."""
+        pass
+    
+    @abstractmethod
+    def get_timeframe_mapping(self) -> Dict[str, str]:
+        """Map standard timeframes to exchange-specific values."""
+        pass
+    
+    @abstractmethod
+    def fetch_candles(
+        self, 
+        symbol: str, 
+        timeframe: str, 
+        start_ms: int, 
+        end_ms: Optional[int] = None,
+        limit: int = 1000,
+        polling: bool = False
+    ) -> List[List[float]]:
+        """Fetch candles from exchange API. Must return format: [timestamp, open, close, high, low, volume]"""
+        pass
+    
+    @abstractmethod
+    def get_api_limits(self) -> Dict[str, int]:
+        """Return API limits and constraints."""
+        pass
+
+class BitfinexAdapter(ExchangeAdapter):
+    """Bitfinex exchange adapter - existing implementation."""
+    
+    API_URL = "https://api-pub.bitfinex.com/v2/candles/trade:{}:{}/hist"
+    API_LIMIT = 10000
+    BACKOFF_INITIAL_SECONDS = 30
+    BACKOFF_MAX_SECONDS = 300
+    
+    def get_exchange_name(self) -> str:
+        return "BITFINEX"
+    
+    def normalize_symbol(self, symbol: str) -> str:
+        return symbol.upper()
+    
+    def get_timeframe_mapping(self) -> Dict[str, str]:
+        return {"1m": "1m", "1h": "1h", "1D": "1D"}
+    
+    def get_api_limits(self) -> Dict[str, int]:
+        return {
+            "max_candles": self.API_LIMIT,
+            "backoff_initial": self.BACKOFF_INITIAL_SECONDS,
+            "backoff_max": self.BACKOFF_MAX_SECONDS,
+            "timeout": HTTP_TIMEOUT_SECONDS
+        }
+    
+    def fetch_candles(
+        self, 
+        symbol: str, 
+        timeframe: str, 
+        start_ms: int, 
+        end_ms: Optional[int] = None,
+        limit: int = 10000,
+        polling: bool = False
+    ) -> List[List[float]]:
+        """Bitfinex candle fetch - reuses existing logic."""
+        url = self.API_URL.format(timeframe, symbol)
+        params = {"limit": min(limit, self.API_LIMIT), "sort": 1, "start": start_ms}
+        if end_ms is not None:
+            params["end"] = end_ms
+        
+        delay = self.BACKOFF_INITIAL_SECONDS
+        headers = {"User-Agent": USER_AGENT}
+        
+        while True:
+            full_url = f"{url}?{urlencode(params)}"
+            
+            if polling:
+                print(f"{POLLING_PREFIX} Bitfinex: {full_url}", flush=True)
+                t0 = time.perf_counter()
+            
+            try:
+                resp = requests.get(full_url, headers=headers, timeout=HTTP_TIMEOUT_SECONDS)
+            except Exception as e:
+                if not polling:
+                    print(f"{ERROR} Bitfinex network error: {e}. Retrying in {delay}s...")
+                time.sleep(delay)
+                delay = min(self.BACKOFF_MAX_SECONDS, delay * 2)
+                continue
+            
+            if resp.status_code == 200:
+                try:
+                    data = resp.json()
+                    if polling and data:
+                        elapsed = time.perf_counter() - t0
+                        print(f"{POLLING_PREFIX} Bitfinex: {len(data)} candles in {elapsed:.3f}s", flush=True)
+                    return data or []
+                except Exception:
+                    return []
+            
+            if resp.status_code == 429:
+                if not polling:
+                    print(f"{WARNING} Bitfinex rate limit (429). Retrying in {delay}s...")
+                time.sleep(delay)
+                delay = min(self.BACKOFF_MAX_SECONDS, delay * 2)
+                continue
+            
+            if not polling:
+                print(f"{ERROR} Bitfinex HTTP {resp.status_code}: {resp.text}")
+            return []
+
+class BinanceFuturesAdapter(ExchangeAdapter):
+    """Binance Futures exchange adapter."""
+    
+    FUTURES_API_URL = "https://fapi.binance.com/fapi/v1/klines"
+    API_LIMIT = 1000
+    BACKOFF_INITIAL_SECONDS = 10
+    BACKOFF_MAX_SECONDS = 120
+    
+    def get_exchange_name(self) -> str:
+        return "BINANCE_FUTURES"
+    
+    def normalize_symbol(self, symbol: str) -> str:
+        return symbol.upper()
+    
+    def get_timeframe_mapping(self) -> Dict[str, str]:
+        return {"1m": "1m", "1h": "1h", "1D": "1d"}
+    
+    def get_api_limits(self) -> Dict[str, int]:
+        return {
+            "max_candles": self.API_LIMIT,
+            "backoff_initial": self.BACKOFF_INITIAL_SECONDS,
+            "backoff_max": self.BACKOFF_MAX_SECONDS,
+            "timeout": HTTP_TIMEOUT_SECONDS
+        }
+    
+    def fetch_candles(
+        self, 
+        symbol: str, 
+        timeframe: str, 
+        start_ms: int, 
+        end_ms: Optional[int] = None,
+        limit: int = 1000,
+        polling: bool = False
+    ) -> List[List[float]]:
+        """Fetch candles from Binance Futures API."""
+        timeframe_mapped = self.get_timeframe_mapping().get(timeframe, timeframe)
+        params = {
+            "symbol": symbol,
+            "interval": timeframe_mapped,
+            "startTime": start_ms,
+            "limit": min(limit, self.API_LIMIT)
+        }
+        if end_ms is not None:
+            params["endTime"] = end_ms
+        
+        delay = self.BACKOFF_INITIAL_SECONDS
+        headers = {"User-Agent": USER_AGENT}
+        
+        while True:
+            full_url = f"{self.FUTURES_API_URL}?{urlencode(params)}"
+            
+            if polling:
+                print(f"{POLLING_PREFIX} Binance: {full_url}", flush=True)
+                t0 = time.perf_counter()
+            
+            try:
+                resp = requests.get(full_url, headers=headers, timeout=HTTP_TIMEOUT_SECONDS)
+            except Exception as e:
+                if not polling:
+                    print(f"{ERROR} Binance Futures network error: {e}. Retrying in {delay}s...")
+                time.sleep(delay)
+                delay = min(self.BACKOFF_MAX_SECONDS, delay * 2)
+                continue
+            
+            if resp.status_code == 200:
+                try:
+                    raw_data = resp.json()
+                    # Convert Binance format to our standard format
+                    converted_data = []
+                    for candle in raw_data:
+                        # [timestamp, open, close, high, low, volume]
+                        converted_data.append([
+                            float(candle[0]),    # timestamp (open time)
+                            float(candle[1]),    # open
+                            float(candle[4]),    # close
+                            float(candle[2]),    # high  
+                            float(candle[3]),    # low
+                            float(candle[5])     # volume (base asset)
+                        ])
+                    
+                    if polling and converted_data:
+                        elapsed = time.perf_counter() - t0
+                        print(f"{POLLING_PREFIX} Binance: {len(converted_data)} candles in {elapsed:.3f}s", flush=True)
+                    
+                    return converted_data
+                    
+                except Exception as e:
+                    if not polling:
+                        print(f"{ERROR} Binance Futures JSON parsing error: {e}")
+                    return []
+            
+            if resp.status_code == 429:
+                if not polling:
+                    print(f"{WARNING} Binance Futures rate limit (429). Retrying in {delay}s...")
+                time.sleep(delay)
+                delay = min(self.BACKOFF_MAX_SECONDS, delay * 2)
+                continue
+            
+            if resp.status_code == 418:  # Binance IP ban
+                if not polling:
+                    print(f"{ERROR} Binance Futures IP banned (418). Waiting {delay * 4}s...")
+                time.sleep(delay * 4)
+                delay = min(self.BACKOFF_MAX_SECONDS, delay * 2)
+                continue
+            
+            if not polling:
+                print(f"{ERROR} Binance Futures HTTP {resp.status_code}: {resp.text}")
+            return []
+
+# ========================== EXCHANGE FACTORY ========================== #
+
+class ExchangeFactory:
+    """Factory for creating exchange adapters."""
+    
+    _adapters = {
+        "BITFINEX": BitfinexAdapter,
+        "BINANCE_FUTURES": BinanceFuturesAdapter,
+    }
+    
+    @classmethod
+    def create_adapter(cls, exchange_name: str) -> ExchangeAdapter:
+        """Create an exchange adapter instance."""
+        exchange_upper = exchange_name.upper()
+        
+        if exchange_upper not in cls._adapters:
+            available = ", ".join(cls._adapters.keys())
+            raise ValueError(f"Unsupported exchange '{exchange_name}'. Available: {available}")
+        
+        adapter_class = cls._adapters[exchange_upper]
+        return adapter_class()
+    
+    @classmethod
+    def list_supported_exchanges(cls) -> List[str]:
+        """Return list of supported exchange names."""
+        return list(cls._adapters.keys())
 
 # ------------------------------ Helpers ----------------------------------- #
 
@@ -234,109 +465,6 @@ def _merge_candle_frames(df_old: pd.DataFrame, df_new: pd.DataFrame) -> Tuple[pd
     out["timestamp"] = out["timestamp"].apply(lambda v: str(int(v)))
     out = out[CSV_COLUMNS]
     return out, int(updated)
-
-def fetch_bitfinex_candles(
-    symbol: str,
-    timeframe: str,
-    start: int,
-    end: Optional[int] = None,
-    limit: int = API_LIMIT,
-    *,
-    polling: bool = False
-) -> List[List[float]]:
-    """
-    Fetches up to `limit` candles from Bitfinex, ascending (sort=1),
-    starting at `start` up to `end` if given.
-    Retries on network/429 with exponential backoff.
-    Returns list of candle arrays or empty list if no data.
-
-    API rows are: [mts, open, close, high, low, volume].
-
-    When `polling=True`, console output is compact and includes timing.
-    """
-    url = BITFINEX_API_URL.format(timeframe, symbol)
-    params = {"limit": limit, "sort": 1, "start": start}
-    if end is not None:
-        params["end"] = end
-
-    delay = BACKOFF_INITIAL_SECONDS
-    max_delay = BACKOFF_MAX_SECONDS
-
-    while True:
-        full = f"{url}?{urlencode(params)}"
-
-        if polling:
-            polling_tag = Fore.MAGENTA + POLLING_PREFIX + Style.RESET_ALL
-            now_utc = datetime.now(timezone.utc)
-            now_str = now_utc.strftime("%Y-%m-%d %H:%M:%S")
-            now_ms = int(now_utc.timestamp() * 1000)
-            print(f"{polling_tag}: Now: {now_str} -- {now_ms}", flush=True)
-            print(f"{polling_tag}: Fetching: {Fore.YELLOW}{full}{Style.RESET_ALL}", flush=True)
-            t0 = time.perf_counter()
-        else:
-            print(f"{INFO} Fetching candles from Bitfinex API...")
-            print(f"       URL: {COLOR_FILE}{full}{Style.RESET_ALL}")
-
-        try:
-            resp = requests.get(full, headers=HEADERS, timeout=HTTP_TIMEOUT_SECONDS)
-        except Exception as e:
-            if not polling:
-                print(f"{ERROR} Network error: {e}. Retrying in {delay}s...")
-            time.sleep(delay)
-            delay = min(max_delay, delay * 2)
-            continue
-
-        if resp.status_code == 200:
-            try:
-                data = resp.json()
-            except Exception as e:
-                if not polling:
-                    print(f"{ERROR} Failed to decode JSON response: {e}")
-                return []
-
-            delay = BACKOFF_INITIAL_SECONDS
-
-            if polling:
-                n = len(data) if data else 0
-                polling_tag = Fore.MAGENTA + POLLING_PREFIX + Style.RESET_ALL
-                if n == 0:
-                    print(f"{polling_tag}: API Returned [0 elements]", flush=True)
-                elif n == 1:
-                    first = json.dumps(data[0], separators=(",", ":"))
-                    print(f"{polling_tag}: API Returned [1 elements]: {first}", flush=True)
-                else:
-                    count_str = f"{Fore.RED}{n}{Style.RESET_ALL}"
-                    first = json.dumps(data[0], separators=(",", ":"))
-                    last  = json.dumps(data[-1], separators=(",", ":"))
-                    print(f"{polling_tag}: API Returned [{count_str} elements]: {first} … {last}", flush=True)
-                elapsed = time.perf_counter() - t0
-                print(f"{polling_tag}: Finished in {elapsed:.3f}s", flush=True)
-                return data
-
-            if not data:
-                print(f"{WARNING} No candles returned from API.")
-                return []
-
-            try:
-                ts = [int(c[0]) for c in data]
-                first_h = datetime.fromtimestamp(min(ts) / 1000, timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-                last_h  = datetime.fromtimestamp(max(ts) / 1000, timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
-                print(f"{SUCCESS} Received {len(data)} candles "
-                      f"({COLOR_TIMESTAMPS}{first_h}{Style.RESET_ALL} → {COLOR_TIMESTAMPS}{last_h}{Style.RESET_ALL})")
-            except Exception:
-                print(f"{SUCCESS} Received {len(data)} candles.")
-            return data
-
-        if resp.status_code == 429:
-            if not polling:
-                print(f"{WARNING} Rate limit hit (429). Retrying in {delay}s...")
-            time.sleep(delay)
-            delay = min(max_delay, delay * 2)
-            continue
-
-        if not polling:
-            print(f"{ERROR} HTTP {resp.status_code}: {resp.text}")
-        return []
 
 def _get_interval_ms(timeframe: str) -> int:
     if timeframe not in INTERVAL_MS:
@@ -749,7 +877,98 @@ def get_last_file_timestamp(
 
 # --------------------------------- SYNC ----------------------------------- #
 
+def _merge_csv_files(dir_path: str, ticker: str, timeframe: str, polling: bool = False) -> None:
+    """Merge all CSV files in the directory into a single sorted file."""
+    if not os.path.exists(dir_path):
+        return
+        
+    # Get all CSV files and sort them by name (which should be dates)
+    csv_files = sorted([f for f in os.listdir(dir_path) if f.endswith('.csv')])
+    if not csv_files:
+        if not polling:
+            print(f"{INFO} No CSV files found to merge in {dir_path}")
+        return
+        
+    # Parse dates from filenames to get date range
+    try:
+        start_date = csv_files[0].replace('.csv', '')
+        end_date = csv_files[-1].replace('.csv', '')
+        output_filename = f"{ticker}_{timeframe}_{start_date}_to_{end_date}.csv"
+        output_path = os.path.join(os.path.dirname(dir_path), output_filename)
+        
+        if not polling:
+            print(f"{INFO} Merging {len(csv_files)} CSV files into {output_filename}...")
+        
+        # Read and combine all CSVs
+        dfs = []
+        for filename in csv_files:
+            filepath = os.path.join(dir_path, filename)
+            try:
+                df = pd.read_csv(filepath, dtype=str)
+                if not df.empty:
+                    dfs.append(df)
+            except Exception as e:
+                if not polling:
+                    print(f"{WARNING} Error reading {filename}: {e}")
+        
+        if not dfs:
+            if not polling:
+                print(f"{WARNING} No valid data found to merge")
+            return
+            
+        # Combine and sort
+        combined = pd.concat(dfs, ignore_index=True)
+        combined['timestamp'] = pd.to_numeric(combined['timestamp'])
+        combined = combined.sort_values('timestamp').drop_duplicates('timestamp')
+        
+        # Save the combined file
+        combined.to_csv(output_path, index=False)
+        if not polling:
+            print(f"{SUCCESS} Successfully created {output_filename} with {len(combined)} rows")
+            
+    except Exception as e:
+        if not polling:
+            print(f"{ERROR} Error merging CSV files: {e}")
+
+def _cleanup_empty_csvs(dir_path: str, ticker: str, timeframe: str, polling: bool = False) -> None:
+    """Remove empty CSV files from the directory and optionally merge remaining files."""
+    if not os.path.exists(dir_path):
+        return
+        
+    # First, clean up empty files
+    empty_count = 0
+    csv_files = []
+    
+    for filename in os.listdir(dir_path):
+        if not filename.endswith('.csv'):
+            continue
+            
+        filepath = os.path.join(dir_path, filename)
+        try:
+            with open(filepath, 'r') as f:
+                lines = f.readlines()
+                if len(lines) <= 1:  # Just headers or empty
+                    os.remove(filepath)
+                    empty_count += 1
+                    if not polling:
+                        print(f"{INFO} Removed empty file: {filename}")
+                else:
+                    csv_files.append(filename)
+        except Exception as e:
+            if not polling:
+                print(f"{WARNING} Error checking {filename}: {e}")
+    
+    # If we found any CSV files, ask about merging
+    if not polling and csv_files and len(csv_files) > 1:
+        try:
+            response = input(f"\n{INFO} Found {len(csv_files)} CSV files. Would you like to merge them into a single file? [y/N] ").strip().lower()
+            if response == 'y':
+                _merge_csv_files(dir_path, ticker, timeframe, polling)
+        except Exception as e:
+            print(f"{WARNING} Error during merge prompt: {e}")
+
 def _bulk_fill_missing(
+    adapter: ExchangeAdapter,
     dir_path: str,
     ticker: str,
     timeframe: str,
@@ -759,13 +978,14 @@ def _bulk_fill_missing(
     polling: bool = False
 ) -> None:
     """Fetch candles in chunk(s) from start_ms..end_ms and save them to CSVs."""
+    api_limits = adapter.get_api_limits()
     cur = start_ms
     while True:
         if end_ms is not None and cur > end_ms:
             break
 
         t_fetch_start = time.perf_counter()
-        data = fetch_bitfinex_candles(ticker, timeframe, cur, end=end_ms, limit=API_LIMIT, polling=polling)
+        data = adapter.fetch_candles(ticker, timeframe, cur, end_ms=end_ms, limit=api_limits["max_candles"], polling=polling)
         t_fetch_end = time.perf_counter()
         if not polling:
             print(f"{INFO} Fetch stage took {(t_fetch_end - t_fetch_start):.3f}s")
@@ -798,12 +1018,15 @@ def _bulk_fill_missing(
             break
 
         cur = last_ts + 1
-        if len(data) < API_LIMIT:
+        if len(data) < api_limits["max_candles"]:
             if end_ms is not None and cur <= end_ms:
                 _create_empty_partitions(dir_path, timeframe, ticker, cur, end_ms, polling=polling)
+            # Clean up any empty CSV files and offer to merge
+            _cleanup_empty_csvs(dir_path, ticker, timeframe, polling=polling)
             break
 
 def _fill_missing_partitions_by_group(
+    adapter: ExchangeAdapter,
     dir_path: str,
     ticker: str,
     timeframe: str,
@@ -846,7 +1069,7 @@ def _fill_missing_partitions_by_group(
                 f"{INFO} Running fill for Group {idx} from {start_ms} ms → {group_end_ms} ms "
                 f"(covering partitions {first_p} .. {last_p})"
             )
-        _bulk_fill_missing(dir_path, ticker, timeframe, start_ms, group_end_ms, polling=polling)
+        _bulk_fill_missing(adapter, dir_path, ticker, timeframe, start_ms, group_end_ms, polling=polling)
 
         # update last_ts_so_far from newly created/updated files
         files_in_dir = sorted(f for f in os.listdir(dir_path) if f.endswith(".csv"))
@@ -870,9 +1093,6 @@ def _trace_utc(msg: str) -> None:
     """Emit a [TRACE] line with an explicit UTC timestamp prefix."""
     print(f"{TRACE} [{_utc_now_str()} UTC] {msg}", flush=True)
 
-
-# --- REPLACEMENT: drop this whole function in place of your existing one --- #
-
 def synchronize_candle_data(
     exchange: str,
     ticker: str,
@@ -882,33 +1102,40 @@ def synchronize_candle_data(
     polling: bool = False
 ) -> bool:
     """
-    Main function to sync historical candles from Bitfinex for a single timeframe.
-
-    Improvements in this version:
-    - Eliminates the silent delay between "Missing N partition(s)..." and the first group print
-      by (a) replacing an O(N) pandas scan across all CSVs with the fast tail scanner and
-      (b) adding explicit, timestamped TRACE logs that bracket each expensive step.
-    - All added trace lines use explicit UTC timestamps in 'YYYY-MM-DD HH:MM:SS' format.
+    Main function to sync historical candles from any supported exchange for a single timeframe.
+    Uses the exchange adapter pattern to support multiple exchanges uniformly.
     """
     if timeframe not in VALID_TIMEFRAMES:
         if not polling:
             print(f"{ERROR} Invalid timeframe '{timeframe}'. Must be one of {VALID_TIMEFRAMES}.")
         return False
 
+    # Create exchange adapter
+    try:
+        adapter = ExchangeFactory.create_adapter(exchange)
+    except ValueError as e:
+        if not polling:
+            print(f"{ERROR} {e}")
+        return False
+
+    # Normalize inputs using adapter
+    exchange_name = adapter.get_exchange_name()
+    normalized_ticker = adapter.normalize_symbol(ticker)
+
     if not polling:
         if not verbose:
             es = f" → {end_date_str}" if end_date_str else ""
-            print(f"{INFO} Syncing {COLOR_VAR}{exchange}/{ticker}/{timeframe}{Style.RESET_ALL}{es}")
+            print(f"{INFO} Syncing {COLOR_VAR}{exchange_name}/{normalized_ticker}/{timeframe}{Style.RESET_ALL}{es}")
         else:
             print(f"\n{INFO} Running synchronization with parameters:\n"
-                  f"  {COLOR_VAR}--exchange{Style.RESET_ALL} {exchange}\n"
-                  f"  {COLOR_VAR}--ticker{Style.RESET_ALL}   {ticker}\n"
+                  f"  {COLOR_VAR}--exchange{Style.RESET_ALL} {exchange_name}\n"
+                  f"  {COLOR_VAR}--ticker{Style.RESET_ALL}   {normalized_ticker}\n"
                   f"  [Timeframe internally set to '{timeframe}']")
             if end_date_str:
                 print(f"  {COLOR_VAR}--end{Style.RESET_ALL}       {end_date_str}")
             print()
 
-    dir_path = ensure_directory(exchange, ticker, timeframe, polling=polling)
+    dir_path = ensure_directory(exchange_name, normalized_ticker, timeframe, polling=polling)
     gotstart_path = os.path.join(dir_path, GOTSTART_FILE)
 
     # Parse end_date (if any)
@@ -929,7 +1156,7 @@ def synchronize_candle_data(
         start_ms = 0  # epoch
         end_ms   = fill_end_ms
 
-        _bulk_fill_missing(dir_path, ticker, timeframe, start_ms, end_ms, polling=polling)
+        _bulk_fill_missing(adapter, dir_path, normalized_ticker, timeframe, start_ms, end_ms, polling=polling)
         with open(gotstart_path, "w") as _:
             pass
         if not polling:
@@ -958,8 +1185,6 @@ def synchronize_candle_data(
         if not polling:
             print(f"{WARNING} Missing {len(missing)} partition(s). Rebuilding missing partitions:\n", flush=True)
 
-        # ---- Added, visible TRACE with UTC: bracket the expensive steps in this gap ---- #
-
         # Step 1: grouping the missing partitions into consecutive runs
         t_grp_start = time.perf_counter()
         _trace_utc(f"Step 1/2: Grouping {len(missing)} missing partition(s) into consecutive runs...")
@@ -968,7 +1193,6 @@ def synchronize_candle_data(
         _trace_utc(f"Step 1/2 complete: {len(grouped)} run(s) in {(t_grp_end - t_grp_start):.3f}s.")
 
         # Step 2: determine the last recorded candle timestamp quickly (fast tail scan)
-        # Choose FS scan trace mode: env override, else 'progress' when verbose, else 'off'.
         env_mode = (os.getenv(ENV_FS_TRACE) or "").strip().lower()
         if env_mode in ("off", "progress", "detailed"):
             fs_trace_mode_for_scan = env_mode
@@ -981,8 +1205,6 @@ def synchronize_candle_data(
             f"(dir={dir_path}, files={len(files)}, mode={fs_trace_mode_for_scan})."
         )
 
-        # IMPORTANT: This replaces the previous O(N) pandas read of every CSV.
-        # It uses the fast tail scanner + minimal pandas fallback (timestamp col only).
         last_ts_so_far: Optional[int] = get_last_file_timestamp(
             dir_path, polling=polling, fs_trace_mode=fs_trace_mode_for_scan
         )
@@ -997,9 +1219,9 @@ def synchronize_candle_data(
                 f"last_ts={last_ts_so_far} ({last_human})."
             )
 
-        # Now proceed to fill the grouped missing partitions (this prints the Group 1... lines)
+        # Fill the grouped missing partitions
         last_ts_so_far = _fill_missing_partitions_by_group(
-            dir_path, ticker, timeframe, grouped, last_ts_so_far, fill_end_ms, polling=polling
+            adapter, dir_path, normalized_ticker, timeframe, grouped, last_ts_so_far, fill_end_ms, polling=polling
         )
 
     else:
@@ -1028,10 +1250,9 @@ def synchronize_candle_data(
 
         if not polling:
             print(f"{INFO} Updating last partition from {recheck_start_ms} ms to {fill_end_ms} ms")
-        _bulk_fill_missing(dir_path, ticker, timeframe, recheck_start_ms, fill_end_ms, polling=polling)
+        _bulk_fill_missing(adapter, dir_path, normalized_ticker, timeframe, recheck_start_ms, fill_end_ms, polling=polling)
 
     # Final: show the last known timestamp (across all partitions)
-    # Choose FS scan trace mode: env override, else 'progress' when verbose, else 'off'.
     env_mode = (os.getenv(ENV_FS_TRACE) or "").strip().lower()
     if env_mode in ("off", "progress", "detailed"):
         fs_trace_mode = env_mode
@@ -1046,32 +1267,48 @@ def synchronize_candle_data(
 
     return True
 
-# --------------------------------- CLI ------------------------------------ #
+# ================================= CLI ================================---- #
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="Sync candle data from Bitfinex.")
-    parser.add_argument("--exchange", required=True, help="Exchange name, e.g. BITFINEX")
-    parser.add_argument("--ticker", required=True, help="Ticker symbol, e.g. tBTCUSD")
-    parser.add_argument(
-        "--timeframe",
-        required=False,
-        default="1m",
-        choices=sorted(VALID_TIMEFRAMES),
-        help="Timeframe to sync (1m, 1h, 1D)."
-    )
-    parser.add_argument("--end", required=False, help="End date (YYYY-MM-DD or YYYY-MM-DD HH:MM)")
-    # Tip: override FS scan trace via env var CANDLESYNC_FS_TRACE=off|progress|detailed
-    args = parser.parse_args()
+    parser = argparse.ArgumentParser(
+        description="Multi-exchange candle data synchronization - Binance Futures + Bitfinex",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=f"""
+Supported Exchanges:
+{chr(10).join('  ' + ex for ex in ExchangeFactory.list_supported_exchanges())}
 
-    exchange = normalize_exchange(args.exchange)
+Examples:
+  # Binance Futures BTC perpetual 1-minute candles
+  python candles_sync.py --exchange BINANCE_FUTURES --ticker BTCUSDT --timeframe 1m
+  
+  # Bitfinex BTC/USD 1-hour candles  
+  python candles_sync.py --exchange BITFINEX --ticker tBTCUSD --timeframe 1h
+        """
+    )
+    
+    parser.add_argument("--exchange", required=True, 
+                       choices=ExchangeFactory.list_supported_exchanges(),
+                       help="Exchange name")
+    parser.add_argument("--ticker", required=True, help="Ticker symbol")
+    parser.add_argument("--timeframe", required=False, default="1m",
+                       choices=["1m", "1h", "1D"], help="Timeframe")
+    parser.add_argument("--end", required=False, 
+                       help="End date (YYYY-MM-DD or 'YYYY-MM-DD HH:MM')")
+    parser.add_argument("--verbose", action="store_true", 
+                       help="Verbose output")
+    parser.add_argument("--polling", action="store_true",
+                       help="Compact polling output")
+    
+    args = parser.parse_args()
 
     print(f"{INFO} Synchronizing single timeframe: {args.timeframe}")
     res = synchronize_candle_data(
-        exchange=exchange,
+        exchange=args.exchange,
         ticker=args.ticker,
         timeframe=args.timeframe,
         end_date_str=args.end,
-        verbose=True
+        verbose=args.verbose,
+        polling=args.polling
     )
     if res:
         print(f"\n{SUCCESS} Synchronization completed successfully for timeframe: {args.timeframe}.\n")


### PR DESCRIPTION
Available symbols from [https://data.binance.vision/?prefix=data/futures/um/daily/klines/]
- Kept internal structure
- same cli command `candles-sync --exchange BINANCE_FUTURES --ticker BTCUSDT --timeframe 1h --end "2025-09-19"`
- added functionality to remove 1970 dated csv by checking if .csv file is empty or has headers but no rows
- optionality after pulling required data, will prompt user y/N, merging files into one file symbol_timeframe_startdate_to_enddate.csv 
- merged csv get output to .corky\BINANCE_FUTURES\candles\SYMBOL, 
- keeping the non merged files in respective timeframe directory .corky\BINANCE_FUTURES\candles\BTCUSDT\1h